### PR TITLE
Add Windows App Service with CDN

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -143,9 +143,30 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_cdn_frontdoor_endpoint.endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint) | resource |
+| [azurerm_cdn_frontdoor_origin.origin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin) | resource |
+| [azurerm_cdn_frontdoor_origin_group.group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group) | resource |
+| [azurerm_cdn_frontdoor_profile.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
+| [azurerm_cdn_frontdoor_route.route](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
+| [azurerm_cdn_frontdoor_rule.add_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule.redirect](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule.remove_response_header](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule_set.add_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
+| [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
+| [azurerm_cdn_frontdoor_rule_set.remove_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_key_vault.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_secret.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_nat_gateway.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway_public_ip_association.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
+| [azurerm_public_ip.nat_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
+| [azurerm_service_plan.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
+| [azurerm_subnet.app_service_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet_nat_gateway_association.app_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_subnet_route_table_association.app_service_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_windows_web_app.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_web_app) | resource |
 | [azuread_user.key_vault_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
@@ -154,11 +175,24 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
+| <a name="input_cdn_frontdoor_health_probe_interval"></a> [cdn\_frontdoor\_health\_probe\_interval](#input\_cdn\_frontdoor\_health\_probe\_interval) | Specifies the number of seconds between health probes. | `number` | `30` | no |
+| <a name="input_cdn_frontdoor_health_probe_path"></a> [cdn\_frontdoor\_health\_probe\_path](#input\_cdn\_frontdoor\_health\_probe\_path) | Specifies the path relative to the origin that is used to determine the health of the origin. | `string` | `"/"` | no |
+| <a name="input_cdn_frontdoor_host_add_response_headers"></a> [cdn\_frontdoor\_host\_add\_response\_headers](#input\_cdn\_frontdoor\_host\_add\_response\_headers) | List of response headers to add at the CDN Front Door `[{ "Name" = "Strict-Transport-Security", "value" = "max-age=31536000" }]` | `list(map(string))` | `[]` | no |
+| <a name="input_cdn_frontdoor_host_redirects"></a> [cdn\_frontdoor\_host\_redirects](#input\_cdn\_frontdoor\_host\_redirects) | CDN FrontDoor host redirects `[{ "from" = "example.com", "to" = "www.example.com" }]` | `list(map(string))` | `[]` | no |
+| <a name="input_cdn_frontdoor_remove_response_headers"></a> [cdn\_frontdoor\_remove\_response\_headers](#input\_cdn\_frontdoor\_remove\_response\_headers) | List of response headers to remove at the CDN Front Door | `list(string)` | `[]` | no |
+| <a name="input_cdn_frontdoor_response_timeout"></a> [cdn\_frontdoor\_response\_timeout](#input\_cdn\_frontdoor\_response\_timeout) | Azure CDN Front Door response timeout in seconds | `number` | n/a | yes |
+| <a name="input_cdn_frontdoor_sku"></a> [cdn\_frontdoor\_sku](#input\_cdn\_frontdoor\_sku) | Azure CDN Front Door SKU | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_service_dotnet_version"></a> [service\_dotnet\_version](#input\_service\_dotnet\_version) | Service dotnet version | `string` | n/a | yes |
+| <a name="input_service_health_check_eviction_time_in_min"></a> [service\_health\_check\_eviction\_time\_in\_min](#input\_service\_health\_check\_eviction\_time\_in\_min) | The amount of time in minutes that a node can be unhealthy before being removed from the load balancer | `number` | n/a | yes |
+| <a name="input_service_health_check_path"></a> [service\_health\_check\_path](#input\_service\_health\_check\_path) | Service health check path | `string` | n/a | yes |
+| <a name="input_service_plan_sku"></a> [service\_plan\_sku](#input\_service\_plan\_sku) | Service plan sku | `string` | n/a | yes |
+| <a name="input_service_worker_count"></a> [service\_worker\_count](#input\_service\_worker\_count) | The number of Workers for the App Service | `number` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
+| <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/app-service.tf
+++ b/terraform/app-service.tf
@@ -1,0 +1,46 @@
+resource "azurerm_service_plan" "default" {
+  name                = "${local.resource_prefix}default"
+  resource_group_name = azurerm_resource_group.default.name
+  location            = azurerm_resource_group.default.location
+  os_type             = "Windows"
+  sku_name            = local.service_plan_sku
+
+  tags = local.tags
+}
+
+resource "azurerm_windows_web_app" "default" {
+  name                = "${local.resource_prefix}default"
+  resource_group_name = azurerm_resource_group.default.name
+  location            = azurerm_service_plan.default.location
+  service_plan_id     = azurerm_service_plan.default.id
+
+  virtual_network_subnet_id = azurerm_subnet.app_service_subnet.id
+  https_only                = true
+
+  site_config {
+    always_on                         = true
+    health_check_path                 = local.service_health_check_path
+    health_check_eviction_time_in_min = local.service_health_check_eviction_time_in_min
+    vnet_route_all_enabled            = true
+    http2_enabled                     = true
+    minimum_tls_version               = "1.2"
+    worker_count                      = local.service_worker_count
+    application_stack {
+      current_stack  = "dotnet"
+      dotnet_version = local.service_dotnet_version
+    }
+    ip_restriction {
+      name   = "Allow CDN Traffic"
+      action = "Allow"
+      headers {
+        x_azure_fdid = [
+          azurerm_cdn_frontdoor_profile.cdn.resource_guid
+        ]
+        x_fd_health_probe = ["1"]
+      }
+      service_tag = "AzureFrontDoor.Backend"
+    }
+  }
+
+  tags = local.tags
+}

--- a/terraform/cdn.tf
+++ b/terraform/cdn.tf
@@ -1,0 +1,140 @@
+resource "azurerm_cdn_frontdoor_profile" "cdn" {
+  name                     = "${local.resource_prefix}cdn"
+  resource_group_name      = azurerm_resource_group.default.name
+  sku_name                 = local.cdn_frontdoor_sku
+  response_timeout_seconds = local.cdn_frontdoor_response_timeout
+  tags                     = local.tags
+}
+
+resource "azurerm_cdn_frontdoor_origin_group" "group" {
+  name                     = "${local.resource_prefix}origingroup"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.cdn.id
+
+  load_balancing {}
+
+  health_probe {
+    protocol            = "Https"
+    interval_in_seconds = local.cdn_frontdoor_health_probe_interval
+    request_type        = "GET"
+    path                = local.cdn_frontdoor_health_probe_path
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "origin" {
+  name                           = "${local.resource_prefix}origin"
+  cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.group.id
+  enabled                        = true
+  certificate_name_check_enabled = true
+  host_name                      = azurerm_windows_web_app.default.default_hostname
+  origin_host_header             = azurerm_windows_web_app.default.default_hostname
+  http_port                      = 80
+  https_port                     = 443
+}
+
+resource "azurerm_cdn_frontdoor_endpoint" "endpoint" {
+  name                     = "${local.resource_prefix}cdnendpoint"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.cdn.id
+  tags                     = local.tags
+}
+
+resource "azurerm_cdn_frontdoor_route" "route" {
+  name                          = "${local.resource_prefix}route"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.endpoint.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.group.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.origin.id]
+  cdn_frontdoor_rule_set_ids    = local.ruleset_ids
+  enabled                       = true
+
+  forwarding_protocol    = "HttpsOnly"
+  https_redirect_enabled = true
+  patterns_to_match      = ["/*"]
+  supported_protocols    = ["Http", "Https"]
+
+  link_to_default_domain = true
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "redirects" {
+  count = length(local.cdn_frontdoor_host_redirects) > 0 ? 1 : 0
+
+  name                     = "${replace(local.resource_prefix, "-", "")}redirects"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.cdn.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "redirect" {
+  for_each = { for index, host_redirect in local.cdn_frontdoor_host_redirects : index => { "from" : host_redirect.from, "to" : host_redirect.to } }
+
+  depends_on = [azurerm_cdn_frontdoor_origin_group.group, azurerm_cdn_frontdoor_origin.origin]
+
+  name                      = "redirect${each.key}"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.redirects[0].id
+  order                     = each.key
+  behavior_on_match         = "Continue"
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "Moved"
+      redirect_protocol    = "Https"
+      destination_hostname = each.value.to
+    }
+  }
+
+  conditions {
+    host_name_condition {
+      operator         = "Equal"
+      negate_condition = false
+      match_values     = [each.value.from]
+      transforms       = ["Lowercase", "Trim"]
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "add_response_headers" {
+  count = length(local.cdn_frontdoor_host_add_response_headers) > 0 ? 1 : 0
+
+  name                     = "${replace(local.resource_prefix, "-", "")}addresponseheaders"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.cdn.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "add_response_headers" {
+  for_each = { for index, response_header in local.cdn_frontdoor_host_add_response_headers : index => { "name" : response_header.name, "value" : response_header.value } }
+
+  depends_on = [azurerm_cdn_frontdoor_origin_group.group, azurerm_cdn_frontdoor_origin.origin]
+
+  name                      = replace("addresponseheaders${each.key}", "-", "")
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.add_response_headers[0].id
+  order                     = 0
+  behavior_on_match         = "Continue"
+
+  actions {
+    response_header_action {
+      header_action = "Overwrite"
+      header_name   = each.value.name
+      value         = each.value.value
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "remove_response_headers" {
+  count = length(local.cdn_frontdoor_remove_response_headers) > 0 ? 1 : 0
+
+  name                     = "${replace(local.resource_prefix, "-", "")}removeresponseheaders"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.cdn.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "remove_response_header" {
+  for_each = toset(local.cdn_frontdoor_remove_response_headers)
+
+  depends_on = [azurerm_cdn_frontdoor_origin_group.group, azurerm_cdn_frontdoor_origin.origin]
+
+  name                      = replace("removeresponseheader${each.value}", "-", "")
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.remove_response_headers[0].id
+  order                     = 0
+  behavior_on_match         = "Continue"
+
+  actions {
+    response_header_action {
+      header_action = "Delete"
+      header_name   = each.value
+    }
+  }
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,9 +1,32 @@
 locals {
-  environment            = var.environment
-  project_name           = var.project_name
-  resource_prefix        = "${local.environment}${local.project_name}"
-  azure_location         = var.azure_location
-  tfvars_filename        = var.tfvars_filename
-  key_vault_access_users = toset(var.key_vault_access_users)
-  tags                   = var.tags
+  environment                               = var.environment
+  project_name                              = var.project_name
+  resource_prefix                           = "${local.environment}${local.project_name}"
+  azure_location                            = var.azure_location
+  tfvars_filename                           = var.tfvars_filename
+  key_vault_access_users                    = toset(var.key_vault_access_users)
+  service_plan_sku                          = var.service_plan_sku
+  service_dotnet_version                    = var.service_dotnet_version
+  service_health_check_path                 = var.service_health_check_path
+  service_health_check_eviction_time_in_min = var.service_health_check_eviction_time_in_min
+  service_worker_count                      = var.service_worker_count
+  virtual_network_address_space             = var.virtual_network_address_space
+  virtual_network_address_space_mask        = element(split("/", local.virtual_network_address_space), 1)
+  app_service_subnet_cidr                   = cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 0)
+  cdn_frontdoor_sku                         = var.cdn_frontdoor_sku
+  cdn_frontdoor_health_probe_interval       = var.cdn_frontdoor_health_probe_interval
+  cdn_frontdoor_health_probe_path           = var.cdn_frontdoor_health_probe_path
+  cdn_frontdoor_response_timeout            = var.cdn_frontdoor_response_timeout
+  cdn_frontdoor_host_redirects              = var.cdn_frontdoor_host_redirects
+  cdn_frontdoor_host_add_response_headers   = var.cdn_frontdoor_host_add_response_headers
+  cdn_frontdoor_remove_response_headers     = var.cdn_frontdoor_remove_response_headers
+  ruleset_redirects_id                      = length(local.cdn_frontdoor_host_redirects) > 0 ? [azurerm_cdn_frontdoor_rule_set.redirects[0].id] : []
+  ruleset_add_response_headers_id           = length(local.cdn_frontdoor_host_add_response_headers) > 0 ? [azurerm_cdn_frontdoor_rule_set.add_response_headers[0].id] : []
+  ruleset_remove_response_headers_id        = length(local.cdn_frontdoor_remove_response_headers) > 0 ? [azurerm_cdn_frontdoor_rule_set.remove_response_headers[0].id] : []
+  ruleset_ids = concat(
+    local.ruleset_redirects_id,
+    local.ruleset_add_response_headers_id,
+    local.ruleset_remove_response_headers_id,
+  )
+  tags = var.tags
 }

--- a/terraform/nat-gateway.tf
+++ b/terraform/nat-gateway.tf
@@ -1,0 +1,29 @@
+resource "azurerm_public_ip" "nat_gateway" {
+  name                = "${local.resource_prefix}natgateway"
+  location            = azurerm_resource_group.default.location
+  resource_group_name = azurerm_resource_group.default.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  ip_version          = "IPv4"
+
+  tags = local.tags
+}
+
+resource "azurerm_nat_gateway" "default" {
+  name                = "${local.resource_prefix}default"
+  location            = azurerm_resource_group.default.location
+  resource_group_name = azurerm_resource_group.default.name
+  sku_name            = "Standard"
+
+  tags = local.tags
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "default" {
+  nat_gateway_id       = azurerm_nat_gateway.default.id
+  public_ip_address_id = azurerm_public_ip.nat_gateway.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "app_service" {
+  nat_gateway_id = azurerm_nat_gateway.default.id
+  subnet_id      = azurerm_subnet.app_service_subnet.id
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,76 @@ variable "key_vault_access_users" {
   type        = list(string)
 }
 
+variable "service_plan_sku" {
+  description = "Service plan sku"
+  type        = string
+}
+
+variable "service_dotnet_version" {
+  description = "Service dotnet version"
+  type        = string
+}
+
+variable "service_health_check_path" {
+  description = "Service health check path"
+  type        = string
+}
+
+variable "service_health_check_eviction_time_in_min" {
+  description = "The amount of time in minutes that a node can be unhealthy before being removed from the load balancer"
+  type        = number
+}
+
+variable "service_worker_count" {
+  description = "The number of Workers for the App Service"
+  type        = number
+}
+
+variable "virtual_network_address_space" {
+  description = "Virtual Network address space CIDR"
+  type        = string
+}
+
+variable "cdn_frontdoor_sku" {
+  description = "Azure CDN Front Door SKU"
+  type        = string
+}
+
+variable "cdn_frontdoor_health_probe_interval" {
+  description = "Specifies the number of seconds between health probes."
+  type        = number
+  default     = 30
+}
+
+variable "cdn_frontdoor_health_probe_path" {
+  description = "Specifies the path relative to the origin that is used to determine the health of the origin."
+  type        = string
+  default     = "/"
+}
+
+variable "cdn_frontdoor_response_timeout" {
+  description = "Azure CDN Front Door response timeout in seconds"
+  type        = number
+}
+
+variable "cdn_frontdoor_host_add_response_headers" {
+  description = "List of response headers to add at the CDN Front Door `[{ \"Name\" = \"Strict-Transport-Security\", \"value\" = \"max-age=31536000\" }]`"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "cdn_frontdoor_remove_response_headers" {
+  description = "List of response headers to remove at the CDN Front Door"
+  type        = list(string)
+  default     = []
+}
+
+variable "cdn_frontdoor_host_redirects" {
+  description = "CDN FrontDoor host redirects `[{ \"from\" = \"example.com\", \"to\" = \"www.example.com\" }]`"
+  type        = list(map(string))
+  default     = []
+}
+
 variable "tags" {
   description = "Tags to be applied to all resources"
   type        = map(string)

--- a/terraform/virtual-network.tf
+++ b/terraform/virtual-network.tf
@@ -1,0 +1,38 @@
+resource "azurerm_virtual_network" "default" {
+  name                = "${local.resource_prefix}default"
+  address_space       = [local.virtual_network_address_space]
+  location            = azurerm_resource_group.default.location
+  resource_group_name = azurerm_resource_group.default.name
+  tags                = local.tags
+}
+
+resource "azurerm_route_table" "default" {
+  name                          = "${local.resource_prefix}default"
+  location                      = azurerm_resource_group.default.location
+  resource_group_name           = azurerm_resource_group.default.name
+  disable_bgp_route_propagation = false
+  tags                          = local.tags
+}
+
+resource "azurerm_subnet" "app_service_subnet" {
+  name                 = "${local.resource_prefix}appservice"
+  virtual_network_name = azurerm_virtual_network.default.name
+  resource_group_name  = azurerm_resource_group.default.name
+  address_prefixes     = [local.app_service_subnet_cidr]
+
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      name = "Microsoft.Web/serverFarms"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet_route_table_association" "app_service_subnet" {
+  subnet_id      = azurerm_subnet.app_service_subnet.id
+  route_table_id = azurerm_route_table.default.id
+}


### PR DESCRIPTION
* Creates a Windows App Service to host the built application
* Creates a virtual network to integrate with the App Service
* Creates a NAT Gateway to provide a static outbound IP address
* Restricts traffic so that all requests have to go via the CDN
* Allows adding/removing headers and adding redirects