### PR TITLE
Fix package path

### DIFF
--- a/.github/workflows/build-and-deploy-app.yml
+++ b/.github/workflows/build-and-deploy-app.yml
@@ -98,12 +98,11 @@ jobs:
             -p:DeployOnBuild=true `
             -p:PackageAsSingleFile=true `
             -p:WebPublishMethod=Package `
-            -p:SkipInvalidConfigurations=true `
-            -p:PackageLocation="build\\"
+            -p:SkipInvalidConfigurations=true
 
       - name: Deploy app to Azure Web Apps
         uses: azure/webapps-deploy@v2
         with:
           app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE  }}
-          package: 'build/'
+          package: './DFE.SIP.API.SharePointOnline/'


### PR DESCRIPTION
* Set `PackageLocation` to default, which will build the package to `./DFE.SIP.API.SharePointOnline/`. Setting it as `build` causes it to be built to `./DFE.SIP.API.SharePointOnline/build`
* Sets the `package` path to `./DFE.SIP.API.SharePointOnline/`