### PR TITLE
Remove `x_fd_health_probe` header restriction

### DIFF
--- a/terraform/app-service.tf
+++ b/terraform/app-service.tf
@@ -37,7 +37,6 @@ resource "azurerm_windows_web_app" "default" {
         x_azure_fdid = [
           azurerm_cdn_frontdoor_profile.cdn.resource_guid
         ]
-        x_fd_health_probe = ["1"]
       }
       service_tag = "AzureFrontDoor.Backend"
     }


### PR DESCRIPTION
* It turns out that having this set, means the rule will only allow health checks