### PR TITLE
Set artifact retention to 1 day

### DIFF
--- a/.github/workflows/build-and-deploy-app.yml
+++ b/.github/workflows/build-and-deploy-app.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           name: package
           path: './DFE.SIP.API.SharePointOnline/obj/Release/Package/PackageTmp/'
+          retention-days: 1
 
   deploy-app:
     name: Deploy to ${{ needs.set-env.outputs.environment }} (${{ needs.set-env.outputs.release }})


### PR DESCRIPTION
Artefacts are uploaded to GitHub but then used immediately in the next step for the deployment to Web App services, so there's no need for them to stick around post-deployment.

Each artefact eats up a portion of a storage quota assigned to this repo so it's important that these are deleted periodically as, according to GitHub docs:
>By default, the artifacts [..] generated by workflows are retained for 90 days before they are automatically deleted.