### PR TITLE
Add SonarCloud scanning

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'zulu'
+        distribution: 'microsoft'
 
     - name: Cache SonarCloud packages
       uses: actions/cache@v3

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -1,0 +1,80 @@
+name: SonarCloud scanning and coverage generation
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+
+env:
+  JAVA_VERSION: '11'
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+    steps:
+    
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
+
+    - name: Install Nuget
+      uses: nuget/setup-nuget@v1
+      with:
+        nuget-version: ${{ needs.set-env.outputs.nuget_version }}
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: NuGet restore
+      run: nuget restore DFE.SIP.API.SharePointOnline.sln
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: 'zulu'
+
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v3
+      with:
+        path: ~\sonar\cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+
+    - name: Cache SonarCloud scanner
+      id: cache-sonar-scanner
+      uses: actions/cache@v3
+      with:
+        path: .\.sonar\scanner
+        key: ${{ runner.os }}-sonar-scanner
+        restore-keys: ${{ runner.os }}-sonar-scanner
+    
+    - name: Install SonarCloud scanner
+      if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+      shell: powershell
+      run: |
+        New-Item -Path .\.sonar\scanner -ItemType Directory
+        dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+
+    # This will need re-enabling once there is coverage to be collected 
+    #- name: Install dotnet reportgenerator
+    #  run: dotnet tool install --global dotnet-reportgenerator-globaltool
+
+    - name: Build, Test and Analyze
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      shell: powershell
+      run: |
+        .\.sonar\scanner\dotnet-sonarscanner begin /k:"API-SIP-SharePointOnline" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        msbuild -p:Configuration=Release `
+            -p:DeployOnBuild=true `
+            -p:PackageAsSingleFile=false `
+            -p:WebPublishMethod=Package `
+            -p:SkipInvalidConfigurations=true
+        .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: ${{ env.JAVA_VERSION }}
         distribution: 'zulu'
 
     - name: Cache SonarCloud packages


### PR DESCRIPTION
Adds SonarCloud scanning capability to the API.

Will perform a scan on each Pull Request opened to check it meets quality gate rules.

**Note**: Since there are currently no tests run as part of the build, code coverage statistics cannot be collected. Once they are available, we can update the workflow to pass the information to SonarCloud