### PR TITLE
Add OWASP ZAP tests and github action

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -1,0 +1,84 @@
+name: Run security scanner tests
+
+on:
+  workflow_dispatch:
+
+env:
+  ZAP_ADDRESS: localhost
+  ZAP_PORT: 9876
+  ZAP_API_KEY: 4d635993-7fdf-4cf1-a089-e0f66dbaa37a
+
+jobs:
+  run-tests-with-zap:
+    name: Run Cypress tests with OWASP ZAP
+    environment: development
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: CypressTests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create directory on runner
+        run: |
+          mkdir -m 777 ${{ github.workspace }}/reports
+
+      - name: Start ZAP container
+        run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/reports/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i owasp/zap2docker-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ env.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Cypress tests
+        env:
+          url: ${{ secrets.AZURE_ENDPOINT }}
+          ZAP_API_KEY: ${{ env.ZAP_API_KEY }}
+          ZAP_ADDRESS: ${{ env.ZAP_ADDRESS }}
+          ZAP_PORT: ${{ env.ZAP_PORT }}
+          HTTP_PROXY: "http://${{ env.ZAP_ADDRESS }}:${{ env.ZAP_PORT }}"
+          NO_PROXY: ".gvt1.com"
+        run: npm run zap
+
+      - name: Upload screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: screenshots-${{ needs.set-env.outputs.environment }}
+          path: CypressTests/cypress/screenshots
+
+      - name: Get git sha
+        if: '!cancelled()'
+        run: |
+          CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+          echo "checked_out_sha=${CHECKED_OUT_SHA}" >> $GITHUB_ENV
+
+      - name: Azure login with SPN
+        if: '!cancelled()'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.OWASP_AZ_CREDENTIALS }}
+
+      - name: Push report to blob storage
+        if: '!cancelled()'
+        uses: azure/CLI@v1
+        id: azure
+        with:
+          azcliversion: 2.49.0
+          inlineScript: |
+            az storage blob upload \
+              --container-name ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} \
+              --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} \
+              --file "${{ github.workspace }}/reports/ZAP-Report.html" \
+              --name "DFE.SIP.API.SharePointOnline/${{ env.checked_out_sha }}/ZAP-Report.html" \
+              --auth-mode login \
+              --overwrite
+      
+      - name: Stop ZAP container
+        if: always()
+        run: docker stop zap_container

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -24,8 +24,23 @@ jobs:
         run: |
           mkdir -m 777 ${{ github.workspace }}/reports
 
+      - name: Restore ZAP container from cache if exists
+        id: cache-docker-zap
+        uses: actions/cache@v3
+        with:
+          path: ~/ci/cache/docker/softwaresecurityproject
+          key: cache-docker-zap-${{ env.ZAP_VERSION }}
+
+      - name: Use cached image if hit
+        if: steps.cache-docker-zap.outputs.cache-hit == 'true'
+        run: docker image load --input ~/ci/cache/docker/softwaresecurityproject/zap-stable-${{ env.ZAP_VERSION }}.tar
+
+      - name: Pull image if no cache hit
+        if: steps.cache-docker-zap.outputs.cache-hit != 'true'
+        run: docker pull softwaresecurityproject/zap-stable:latest && mkdir -p ~/ci/cache/docker/softwaresecurityproject && docker image save softwaresecurityproject/zap-stable:latest --output ~/ci/cache/docker/softwaresecurityproject/zap-stable-${{ env.ZAP_VERSION }}.tar
+
       - name: Start ZAP container
-        run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/reports/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i owasp/zap2docker-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ env.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
+        run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/reports/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i softwaresecurityproject/zap-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ env.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
 
       - name: Set up NodeJS
         uses: actions/setup-node@v3

--- a/CypressTests/cypress.config.js
+++ b/CypressTests/cypress.config.js
@@ -1,10 +1,20 @@
 const { defineConfig } = require("cypress");
 require("dotenv").config(); // Load the .env file
+import { generateZapReport } from './cypress/plugins/generateZapReport'
 
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+      on('before:run', () => {
+        // Map cypress env vars to process env vars for usage outside of Cypress run
+        process.env = config.env
+      })
+
+      on('after:run', async () => {
+        if(process.env.ZAP) {
+          await generateZapReport()
+        }
+      })
     },
   },
   env: {

--- a/CypressTests/cypress/plugins/generateZapReport.js
+++ b/CypressTests/cypress/plugins/generateZapReport.js
@@ -1,0 +1,49 @@
+const ZapClient = require('zaproxy')
+const fs = require('fs')
+
+module.exports = {
+  generateZapReport: async () => {
+    const zapOptions = {
+      apiKey: process.env.zapApiKey,
+      proxy: {
+          host: process.env.zapAddress,
+          port: process.env.zapPort
+      }
+    }
+    const zaproxy = new ZapClient(zapOptions)
+    // Wait for passive scanner to finish scanning before generating report
+    let recordsRemaining = 100
+    while (recordsRemaining !== 0) {
+      await zap.pscan.recordsToScan()
+        .then((resp) => {
+          try {
+            recordsRemaining = parseInt(resp.recordsToScan, 10)
+          } catch (err) {
+            if (err instanceof Error) {
+              console.log(`Error converting result: ${err.message}`)
+            } else {
+              console.log('Unknown error during results conversion')
+            }
+            recordsRemaining = 0
+          }
+        })
+        .catch((err) => {
+          console.log(`Error from the ZAP Passive Scan API: ${err}`)
+          recordsRemaining = 0
+        })
+    }
+
+    await zap.reports.generate({
+      title: 'Report',
+      template: 'traditional-html',
+      reportfilename: 'ZAP-Report.html',
+      reportdir: '/zap/wrk'
+    })
+    .then((resp) => {
+      console.log(`${JSON.stringify(resp)}`)
+    })
+    .catch((err) => {
+      console.log(`Error from ZAP Report API: ${err}`)
+    })
+    }
+  }

--- a/CypressTests/package-lock.json
+++ b/CypressTests/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "eslint": "^8.45.0",
-        "eslint-plugin-cypress": "^2.13.3"
+        "eslint-plugin-cypress": "^2.13.3",
+        "zaproxy": "^2.0.0-rc.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -400,6 +401,37 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1189,6 +1221,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -2562,6 +2614,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zaproxy": {
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/zaproxy/-/zaproxy-2.0.0-rc.2.tgz",
+      "integrity": "sha512-OH9CtBgem9vcB25/qVQaxp30dFiChW7VsHuTCC1nodyR4FkqiicTF6/cX3MGaeJTssRpDUmZMGfsDxs+wsGKsw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=17.0.0"
+      }
     }
   },
   "dependencies": {
@@ -2845,6 +2909,36 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+    },
+    "axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -3421,6 +3515,12 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "forever-agent": {
@@ -4382,6 +4482,15 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zaproxy": {
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/zaproxy/-/zaproxy-2.0.0-rc.2.tgz",
+      "integrity": "sha512-OH9CtBgem9vcB25/qVQaxp30dFiChW7VsHuTCC1nodyR4FkqiicTF6/cX3MGaeJTssRpDUmZMGfsDxs+wsGKsw==",
+      "dev": true,
+      "requires": {
+        "axios": "^1.3.3"
+      }
     }
   }
 }

--- a/CypressTests/package.json
+++ b/CypressTests/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "cy:run": "cypress run --env url=$url",
     "cy:open": "cypress open",
-    "lint": "eslint . --ext .cy.js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .cy.js,.jsx,.ts,.tsx",
+    "zap": "cypress run --env url=$url,zap=true,zapAddress=$ZAP_ADDRESS,zapPort=$ZAP_PORT,zapApiKey=$ZAP_API_KEY"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "eslint": "^8.45.0",
-    "eslint-plugin-cypress": "^2.13.3"
+    "eslint-plugin-cypress": "^2.13.3",
+    "zaproxy": "^2.0.0-rc.2"
   }
 }


### PR DESCRIPTION
## What's the change?

Adds an extension to the Cypress tests which allows proxying and report generation with [OWASP ZAP](https://www.zaproxy.org/).

Also adds a workflow for a security tests GitHub action.

Generated reports are uploaded to blob storage to be available within RSD.