### PR TITLE
Add Cypress User-agent to config

### DIFF
--- a/CypressTests/cypress.config.js
+++ b/CypressTests/cypress.config.js
@@ -21,4 +21,5 @@ module.exports = defineConfig({
     url: process.env.url,
     video: false
   },
+  userAgent: 'SipApiSharePointOnline/1.0 Cypress',
 });


### PR DESCRIPTION
Adds a User-Agent header to Cypress' config to mitigate Azure's bot traffic rules