### PR TITLE
Bump azure actions to v2

### DIFF
--- a/.github/workflows/build-and-deploy-app.yml
+++ b/.github/workflows/build-and-deploy-app.yml
@@ -90,7 +90,7 @@ jobs:
           nuget-version: ${{ needs.set-env.outputs.nuget_version }}
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@2
 
       - name: NuGet restore
         run: nuget restore DFE.SIP.API.SharePointOnline.sln

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Azure login with SPN
         if: '!cancelled()'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.OWASP_AZ_CREDENTIALS }}
 


### PR DESCRIPTION
Bumps actions versions to remove node 16 deprecation warnings