### PR TITLE
157331: added app insights logging

### DIFF
--- a/DFE.SIP.API.SharePointOnline.Tests/App.config
+++ b/DFE.SIP.API.SharePointOnline.Tests/App.config
@@ -115,7 +115,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.21.0.429" newVersion="2.21.0.429" />
+        <bindingRedirect oldVersion="0.0.0.0-2.22.0.997" newVersion="2.22.0.997" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/DFE.SIP.API.SharePointOnline/ApplicationInsights.config
+++ b/DFE.SIP.API.SharePointOnline/ApplicationInsights.config
@@ -1,0 +1,137 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
+	<TelemetryInitializers>
+		<Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector" />
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer" />
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.BuildInfoConfigComponentVersionTelemetryInitializer, Microsoft.AI.WindowsServer" />
+		<Add Type="Microsoft.ApplicationInsights.Web.WebTestTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.SyntheticUserAgentTelemetryInitializer, Microsoft.AI.Web">
+			<!-- Extended list of bots:
+            search|spider|crawl|Bot|Monitor|BrowserMob|BingPreview|PagePeeker|WebThumb|URL2PNG|ZooShot|GomezA|Google SketchUp|Read Later|KTXN|KHTE|Keynote|Pingdom|AlwaysOn|zao|borg|oegp|silk|Xenu|zeal|NING|htdig|lycos|slurp|teoma|voila|yahoo|Sogou|CiBra|Nutch|Java|JNLP|Daumoa|Genieo|ichiro|larbin|pompos|Scrapy|snappy|speedy|vortex|favicon|indexer|Riddler|scooter|scraper|scrubby|WhatWeb|WinHTTP|voyager|archiver|Icarus6j|mogimogi|Netvibes|altavista|charlotte|findlinks|Retreiver|TLSProber|WordPress|wsr-agent|http client|Python-urllib|AppEngine-Google|semanticdiscovery|facebookexternalhit|web/snippet|Google-HTTP-Java-Client-->
+			<Filters>search|spider|crawl|Bot|Monitor|AlwaysOn</Filters>
+		</Add>
+		<Add Type="Microsoft.ApplicationInsights.Web.ClientIpHeaderTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.AzureAppServiceRoleNameFromHostNameHeaderInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.OperationNameTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.OperationCorrelationTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.UserTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.AuthenticatedUserIdTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.AccountIdTelemetryInitializer, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.SessionTelemetryInitializer, Microsoft.AI.Web" />
+	</TelemetryInitializers>
+	<TelemetryModules>
+		<Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
+			<ExcludeComponentCorrelationHttpHeadersOnDomains>
+				<!-- 
+        Requests to the following hostnames will not be modified by adding correlation headers.         
+        Add entries here to exclude additional hostnames.
+        NOTE: this configuration will be lost upon NuGet upgrade.
+        -->
+				<Add>core.windows.net</Add>
+				<Add>core.chinacloudapi.cn</Add>
+				<Add>core.cloudapi.de</Add>
+				<Add>core.usgovcloudapi.net</Add>
+			</ExcludeComponentCorrelationHttpHeadersOnDomains>
+			<IncludeDiagnosticSourceActivities>
+				<Add>Microsoft.Azure.EventHubs</Add>
+				<Add>Azure.Messaging.ServiceBus</Add>
+			</IncludeDiagnosticSourceActivities>
+		</Add>
+		<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
+			<!--
+      Use the following syntax here to collect additional performance counters:
+
+      <Counters>
+        <Add PerformanceCounter="\Process(??APP_WIN32_PROC??)\Handle Count" ReportAs="Process handle count" />
+        ...
+      </Counters>
+
+      PerformanceCounter must be either \CategoryName(InstanceName)\CounterName or \CategoryName\CounterName
+
+      NOTE: performance counters configuration will be lost upon NuGet upgrade.
+
+      The following placeholders are supported as InstanceName:
+        ??APP_WIN32_PROC?? - instance name of the application process  for Win32 counters.
+        ??APP_W3SVC_PROC?? - instance name of the application IIS worker process for IIS/ASP.NET counters.
+        ??APP_CLR_PROC?? - instance name of the application CLR process for .NET counters.
+      -->
+		</Add>
+		<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryModule, Microsoft.AI.PerfCounterCollector" />
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.AppServicesHeartbeatTelemetryModule, Microsoft.AI.WindowsServer" />
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureInstanceMetadataTelemetryModule, Microsoft.AI.WindowsServer">
+			<!--
+      Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider 
+      with the following syntax:
+
+      <Add Type="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule, Microsoft.ApplicationInsights">
+        <ExcludedHeartbeatProperties>
+          <Add>osType</Add>
+          <Add>location</Add>
+          <Add>name</Add>
+          <Add>offer</Add>
+          <Add>platformFaultDomain</Add>
+          <Add>platformUpdateDomain</Add>
+          <Add>publisher</Add>
+          <Add>sku</Add>
+          <Add>version</Add>
+          <Add>vmId</Add>
+          <Add>vmSize</Add>
+          <Add>subscriptionId</Add>
+          <Add>resourceGroupName</Add>
+          <Add>placementGroupId</Add>
+          <Add>tags</Add>
+          <Add>vmScaleSetName</Add>
+        </ExcludedHeartbeatProperties>
+      </Add>
+
+      NOTE: exclusions will be lost upon upgrade.
+      -->
+		</Add>
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.DeveloperModeWithDebuggerAttachedTelemetryModule, Microsoft.AI.WindowsServer" />
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.UnhandledExceptionTelemetryModule, Microsoft.AI.WindowsServer" />
+		<Add Type="Microsoft.ApplicationInsights.WindowsServer.UnobservedExceptionTelemetryModule, Microsoft.AI.WindowsServer">
+			<!--</Add>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.FirstChanceExceptionStatisticsTelemetryModule, Microsoft.AI.WindowsServer">-->
+		</Add>
+		<Add Type="Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule, Microsoft.AI.Web">
+			<Handlers>
+				<!-- 
+        Add entries here to filter out additional handlers: 
+
+        NOTE: handler configuration will be lost upon NuGet upgrade.
+        -->
+				<Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
+				<Add>System.Web.StaticFileHandler</Add>
+				<Add>System.Web.Handlers.AssemblyResourceLoader</Add>
+				<Add>System.Web.Optimization.BundleHandler</Add>
+				<Add>System.Web.Script.Services.ScriptHandlerFactory</Add>
+				<Add>System.Web.Handlers.TraceHandler</Add>
+				<Add>System.Web.Services.Discovery.DiscoveryRequestHandler</Add>
+				<Add>System.Web.HttpDebugHandler</Add>
+			</Handlers>
+		</Add>
+		<Add Type="Microsoft.ApplicationInsights.Web.ExceptionTrackingTelemetryModule, Microsoft.AI.Web" />
+		<Add Type="Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule, Microsoft.AI.Web" />
+	</TelemetryModules>
+	<ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights" />
+	<TelemetrySinks>
+		<Add Name="default">
+			<TelemetryProcessors>
+				<Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector" />
+				<Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights" />
+				<Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+					<MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+					<ExcludedTypes>Event</ExcludedTypes>
+				</Add>
+				<Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+					<MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+					<IncludedTypes>Event</IncludedTypes>
+				</Add>
+				<!--
+          Adjust the include and exclude examples to specify the desired semicolon-delimited types. (Dependency, Event, Exception, PageView, Request, Trace)
+        -->
+			</TelemetryProcessors>
+			<TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
+		</Add>
+	</TelemetrySinks>
+</ApplicationInsights>

--- a/DFE.SIP.API.SharePointOnline/Controllers/HealthInternalStatusOnlyController.cs
+++ b/DFE.SIP.API.SharePointOnline/Controllers/HealthInternalStatusOnlyController.cs
@@ -26,10 +26,6 @@ namespace DFE.SIP.API.SharePointOnline.Controllers
         {
             AppSettingsManager appSettings = new AppSettingsManager();
             return "BuildVersion:" + appSettings.Get(appSettings.BuildVersion);
-
-          
         }
-
-
     }
 }

--- a/DFE.SIP.API.SharePointOnline/DFE.SIP.API.SharePointOnline.csproj
+++ b/DFE.SIP.API.SharePointOnline/DFE.SIP.API.SharePointOnline.csproj
@@ -55,8 +55,26 @@
     <Reference Include="Azure.Core, Version=1.25.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
       <HintPath>..\packages\Azure.Core.1.25.0\lib\net461\Azure.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.21.0.429, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.21.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.22.0.997, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.22.0\lib\net452\Microsoft.AI.DependencyCollector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.22.0.997, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.22.0\lib\net452\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.22.0.997, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.22.0\lib\net452\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AI.Web, Version=2.22.0.997, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.Web.2.22.0\lib\net452\Microsoft.AI.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AI.WindowsServer, Version=2.22.0.997, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.2.22.0\lib\net452\Microsoft.AI.WindowsServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.22.0.997, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.22.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.8\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
@@ -316,6 +334,7 @@
     <Reference Include="System.IO.Pipelines, Version=6.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Pipelines.6.0.3\lib\net461\System.IO.Pipelines.dll</HintPath>
     </Reference>
+    <Reference Include="System.Management" />
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
@@ -343,6 +362,7 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
@@ -529,6 +549,7 @@
     <Folder Include="App_Data\" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="ApplicationInsights.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <PropertyGroup>
@@ -570,9 +591,19 @@
     <Error Condition="!Exists('..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.2\build\Microsoft.Extensions.Logging.Abstractions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.2\build\Microsoft.Extensions.Logging.Abstractions.targets'))" />
     <Error Condition="!Exists('..\packages\System.Text.Json.6.0.6\build\System.Text.Json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Text.Json.6.0.6\build\System.Text.Json.targets'))" />
     <Error Condition="!Exists('..\packages\Sentry.3.24.0\build\Sentry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Sentry.3.24.0\build\Sentry.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.22.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.22.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.22.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.22.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.WindowsServer.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.Web.2.22.0\build\Microsoft.ApplicationInsights.Web.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.Web.2.22.0\build\Microsoft.ApplicationInsights.Web.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.2\build\Microsoft.Extensions.Logging.Abstractions.targets" Condition="Exists('..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.2\build\Microsoft.Extensions.Logging.Abstractions.targets')" />
   <Import Project="..\packages\System.Text.Json.6.0.6\build\System.Text.Json.targets" Condition="Exists('..\packages\System.Text.Json.6.0.6\build\System.Text.Json.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.22.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.22.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.22.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.22.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.WindowsServer.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.2.22.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.Web.2.22.0\build\Microsoft.ApplicationInsights.Web.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.Web.2.22.0\build\Microsoft.ApplicationInsights.Web.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DFE.SIP.API.SharePointOnline/Global.asax.cs
+++ b/DFE.SIP.API.SharePointOnline/Global.asax.cs
@@ -1,37 +1,14 @@
 ﻿using Sentry;
-using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Web;
+using Sentry.AspNet;
 using System.Web.Http;
 using System.Web.Mvc;
-using System.Web.Routing;
-using Sentry.AspNet;
 
 namespace DFE.SIP.API.SharePointOnline
 {
     public class WebApiApplication : System.Web.HttpApplication
     {
-        private IDisposable _sentry;
-
         protected void Application_Start()
         {
-            _sentry = SentrySdk.Init(o =>
-            {
-                // We store the DSN inside Web.config; make sure to use your own DSN!
-                o.Dsn = ConfigurationManager.AppSettings["SentryDSN"];
-                o.Environment = ConfigurationManager.AppSettings["Environment"].ToLower();
-                o.SendDefaultPii = true;
-                o.AttachStacktrace = true;
-                o.TracesSampleRate = 1.0;
-#if DEBUG
-                o.Debug = true;
-#endif
-                // Get ASP.NET integration
-                o.AddAspNet();
-            });
-
             // AreaRegistration.RegisterAllAreas();
             GlobalConfiguration.Configure(WebApiConfig.Register);
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
@@ -46,12 +23,6 @@ namespace DFE.SIP.API.SharePointOnline
 
             // Capture unhandled exceptions
             SentrySdk.CaptureException(exception);
-        }
-
-        protected void Application_End()
-        {
-            // Close the Sentry SDK (flushes queued events to Sentry)
-            _sentry?.Dispose();
         }
 
         protected void Application_BeginRequest()

--- a/DFE.SIP.API.SharePointOnline/Utilities/TelemetryFactory.cs
+++ b/DFE.SIP.API.SharePointOnline/Utilities/TelemetryFactory.cs
@@ -13,10 +13,11 @@ namespace DFE.SIP.API.SharePointOnline.Utilities
         {
             if (_telemetryClient == null)
             {
-                var config = new TelemetryConfiguration();
-                config.ConnectionString = $"InstrumentationKey={AppSettings.Get(AppSettings.APPINSIGHTS_KEY)}";
+                // Overrides the ApplicationInsights.config connection string
+                TelemetryConfiguration.Active.ConnectionString = $"InstrumentationKey={AppSettings.Get(AppSettings.APPINSIGHTS_KEY)}";
 
-                _telemetryClient = new TelemetryClient(config);
+                _telemetryClient = new TelemetryClient();
+
                 _telemetryClient.Context.GlobalProperties.Add(InsightMetrics.Environment, AppSettings.Get(AppSettings.Environment));
                 _telemetryClient.Context.GlobalProperties.Add(InsightMetrics.Application, "SIP API SharePoint Online");
                 _telemetryClient.Context.GlobalProperties.Add(InsightMetrics.Function, "Api Request");

--- a/DFE.SIP.API.SharePointOnline/Web.config
+++ b/DFE.SIP.API.SharePointOnline/Web.config
@@ -26,7 +26,6 @@
     <add key="A2CEntitiesAllowedToCRUDFiles" value="sip_application,sip_applyingschools" />
     <add key="BuildVersion" value="0.1" />-->
     <add key="SentryDSN" value="https://6acb7fb7ef0349c8bc8362941b7ebe2c@o1042804.ingest.sentry.io/4504202080288768" />
-
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -41,6 +40,7 @@
     <httpRuntime targetFramework="4.6.1" maxRequestLength="70200" executionTimeout="120" />
     <httpModules>
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
   </system.web>
   <system.webServer>
@@ -52,6 +52,8 @@
     <modules>
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" />
+      <remove name="ApplicationInsightsWebTracking" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
     </modules>
     <rewrite>
       <rules>
@@ -122,7 +124,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.21.0.429" newVersion="2.21.0.429" />
+        <bindingRedirect oldVersion="0.0.0.0-2.22.0.997" newVersion="2.22.0.997" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/DFE.SIP.API.SharePointOnline/packages.config
+++ b/DFE.SIP.API.SharePointOnline/packages.config
@@ -4,7 +4,13 @@
   <package id="AngleSharp.Css" version="0.16.4" targetFramework="net48" />
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
   <package id="Azure.Core" version="1.25.0" targetFramework="net48" />
-  <package id="Microsoft.ApplicationInsights" version="2.21.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights" version="2.22.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.22.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.22.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.Web" version="2.22.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.22.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.22.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.9" targetFramework="net48" />
   <package id="Microsoft.AspNet.Razor" version="3.2.9" targetFramework="net48" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.8" targetFramework="net48" />


### PR DESCRIPTION
Added app insights telemetry and removed sentry. Since this is a .NET framework app, the following guide was followed, using the manual install route:

https://learn.microsoft.com/en-us/azure/azure-monitor/app/asp-net

The connection string is set programatically using the TelemetryClient.Active.ConnectionString property, to override the AppInsights.config file.

Tested against the DEV and TEST environments