### PR TITLE
Disable CDN health probes

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -164,6 +164,7 @@ No resources.
 | <a name="input_cdn_frontdoor_response_timeout"></a> [cdn\_frontdoor\_response\_timeout](#input\_cdn\_frontdoor\_response\_timeout) | Azure CDN Front Door response timeout in seconds | `number` | n/a | yes |
 | <a name="input_cdn_frontdoor_sku"></a> [cdn\_frontdoor\_sku](#input\_cdn\_frontdoor\_sku) | Azure CDN Front Door SKU | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Web App default hostname as the origin. | `bool` | n/a | yes |
+| <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `false` | no |
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send App Service logs to an Event Hub sink | `bool` | `false` | no |
 | <a name="input_enable_logstash_consumer"></a> [enable\_logstash\_consumer](#input\_enable\_logstash\_consumer) | Create an Event Hub consumer group for Logstash | `bool` | `false` | no |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Web App Service | `bool` | n/a | yes |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -34,6 +34,7 @@ locals {
   cdn_frontdoor_origin_fqdn_override              = var.cdn_frontdoor_origin_fqdn_override
   cdn_frontdoor_origin_host_header_override       = var.cdn_frontdoor_origin_host_header_override
   cdn_frontdoor_forwarding_protocol               = var.cdn_frontdoor_forwarding_protocol
+  enable_cdn_frontdoor_health_probe               = var.enable_cdn_frontdoor_health_probe
   restrict_web_app_service_to_cdn_inbound_only    = var.restrict_web_app_service_to_cdn_inbound_only
   web_app_service_allow_ips_inbound               = var.web_app_service_allow_ips_inbound
   enable_event_hub                                = var.enable_event_hub

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -140,6 +140,12 @@ variable "cdn_frontdoor_sku" {
   type        = string
 }
 
+variable "enable_cdn_frontdoor_health_probe" {
+  description = "Enable CDN Front Door health probe"
+  type        = bool
+  default     = false
+}
+
 variable "cdn_frontdoor_health_probe_interval" {
   description = "Specifies the number of seconds between health probes."
   type        = number

--- a/terraform/web-app-service.tf
+++ b/terraform/web-app-service.tf
@@ -44,4 +44,5 @@ module "azure_web_app_services_hosting" {
   cdn_frontdoor_origin_fqdn_override              = local.cdn_frontdoor_origin_fqdn_override
   cdn_frontdoor_origin_host_header_override       = local.cdn_frontdoor_origin_host_header_override
   cdn_frontdoor_forwarding_protocol               = local.cdn_frontdoor_forwarding_protocol
+  enable_cdn_frontdoor_health_probe               = local.enable_cdn_frontdoor_health_probe
 }


### PR DESCRIPTION
Front Door's health probes are designed to detect situations where an origin is unavailable or unhealthy. When a health probe detects a problem with an origin, Front Door can be configured to send traffic to another origin in the origin group.

If you only have a single origin, Front Door always routes traffic to that origin even if its health probe reports an unhealthy status. The status of the health probe doesn't do anything to change Front Door's behavior. In this scenario, health probes don't provide a benefit and you should disable them to reduce the traffic on your origin.