### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'DFE.*'
+      - '!CypressTests'
+      - '*.csproj'
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize, reopened ]
+    paths:
+      - 'DFE.*'
+      - '!CypressTests'
+      - '*.csproj'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners