### PR TITLE
Update .NET sonar scanner workflow

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -6,13 +6,12 @@ on:
   pull_request:
 
 env:
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '21'
 
 jobs:
   build-and-test:
     runs-on: windows-latest
     steps:
-    
     - name: Checkout code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -48,17 +48,13 @@ jobs:
         New-Item -Path .\.sonar\scanner -ItemType Directory
         dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
-    # This will need re-enabling once there is coverage to be collected 
-    #- name: Install dotnet reportgenerator
-    #  run: dotnet tool install --global dotnet-reportgenerator-globaltool
-
     - name: Build, Test and Analyze
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: powershell
       run: |
-        .\.sonar\scanner\dotnet-sonarscanner begin /k:"API-SIP-SharePointOnline" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        .\.sonar\scanner\dotnet-sonarscanner begin /d:sonar.qualitygate.wait=true /k:"API-SIP-SharePointOnline" /d:sonar.scanner.skipJreProvisioning=true /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
         msbuild -p:Configuration=Release `
             -p:DeployOnBuild=true `
             -p:PackageAsSingleFile=false `

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -2,17 +2,8 @@ name: SonarCloud scanning and coverage generation
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'DFE.*/**'
-      - '!CypressTests/**'
-  pull_request:
     branches: [ master ]
-    types: [ opened, synchronize, reopened ]
-    paths:
-      - 'DFE.*/**'
-      - '!CypressTests/**'
+  pull_request:
 
 env:
   JAVA_VERSION: '17'

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -20,8 +20,6 @@ jobs:
 
     - name: Install Nuget
       uses: nuget/setup-nuget@v2
-      with:
-        nuget-version: ${{ needs.set-env.outputs.nuget_version }}
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3
@@ -35,13 +33,6 @@ jobs:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'microsoft'
 
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v4
-      with:
-        path: ~\sonar\cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-
     - name: Cache SonarCloud scanner
       id: cache-sonar-scanner
       uses: actions/cache@v4
@@ -49,7 +40,7 @@ jobs:
         path: .\.sonar\scanner
         key: ${{ runner.os }}-sonar-scanner
         restore-keys: ${{ runner.os }}-sonar-scanner
-    
+
     - name: Install SonarCloud scanner
       if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
       shell: powershell


### PR DESCRIPTION
This forms part of the work to make Sonarqube a mandatory quality gate.
Introducing the `sonar.qualitygate.wait=true` parameter ensures that the scanner will wait for the report to be generated and will fail the workflow if the gate is red, rather than completing the workflow regardless of the gate
Additionally, the `sonar.scanner.skipJreProvisioning=true` means it will skip installing the Java SDK as we have included that as a prior step in the workflow