### PR TITLE
Don't deploy to environment on push to master

### DIFF
--- a/.github/workflows/build-and-deploy-app.yml
+++ b/.github/workflows/build-and-deploy-app.yml
@@ -1,9 +1,6 @@
 name: Deploy to environment
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
* The master branch currently has bugs that need to be investigated/resolved. Until that has happened, we should prevent it deploying to the Dev environment